### PR TITLE
Fix Books Page: Remove page displays and fix NaN% progress issue

### DIFF
--- a/app/books/page.js
+++ b/app/books/page.js
@@ -12,8 +12,7 @@ export default function BooksPage() {
   const [formData, setFormData] = useState({
     title: '',
     author: '',
-    total_pages: '',
-    current_page: 0,
+    progress: 0,
     status: 'reading'
   })
 
@@ -45,8 +44,7 @@ export default function BooksPage() {
           .from('books')
           .update({
             ...formData,
-            total_pages: parseInt(formData.total_pages),
-            current_page: parseInt(formData.current_page)
+            progress: parseInt(formData.progress) || 0
           })
           .eq('id', editingId)
         if (error) throw error
@@ -55,8 +53,7 @@ export default function BooksPage() {
           .from('books')
           .insert([{
             ...formData,
-            total_pages: parseInt(formData.total_pages),
-            current_page: parseInt(formData.current_page)
+            progress: parseInt(formData.progress) || 0
           }])
         if (error) throw error
       }
@@ -88,8 +85,7 @@ export default function BooksPage() {
     setFormData({
       title: book.title,
       author: book.author,
-      total_pages: book.total_pages.toString(),
-      current_page: book.current_page,
+      progress: book.progress || 0,
       status: book.status
     })
     setEditingId(book.id)
@@ -100,16 +96,11 @@ export default function BooksPage() {
     setFormData({
       title: '',
       author: '',
-      total_pages: '',
-      current_page: 0,
+      progress: 0,
       status: 'reading'
     })
     setEditingId(null)
     setShowForm(false)
-  }
-
-  function calculateProgress(current, total) {
-    return Math.round((current / total) * 100)
   }
 
   if (loading) {
@@ -182,24 +173,14 @@ export default function BooksPage() {
                 />
               </div>
               <div>
-                <label className="label">Total Pages *</label>
-                <input
-                  type="number"
-                  required
-                  min="1"
-                  className="input-field"
-                  value={formData.total_pages}
-                  onChange={(e) => setFormData({ ...formData, total_pages: e.target.value })}
-                />
-              </div>
-              <div>
-                <label className="label">Current Page</label>
+                <label className="label">Progress (%)</label>
                 <input
                   type="number"
                   min="0"
+                  max="100"
                   className="input-field"
-                  value={formData.current_page}
-                  onChange={(e) => setFormData({ ...formData, current_page: parseInt(e.target.value) || 0 })}
+                  value={formData.progress}
+                  onChange={(e) => setFormData({ ...formData, progress: parseInt(e.target.value) || 0 })}
                 />
               </div>
               <div>
@@ -241,15 +222,14 @@ export default function BooksPage() {
           </div>
         ) : (
           books.map((book) => {
-            const progress = calculateProgress(book.current_page, book.total_pages)
+            const progress = book.progress || 0
             return (
               <div key={book.id} className="card p-6">
                 <div className="flex justify-between items-start mb-4">
                   <div className="flex-1">
                     <h3 className="text-xl font-semibold text-gray-900">{book.title}</h3>
                     <p className="text-gray-600">by {book.author}</p>
-                    <div className="mt-2 flex items-center space-x-4 text-sm text-gray-500">
-                      <span>{book.current_page} / {book.total_pages} pages</span>
+                    <div className="mt-2 flex items-center space-x-4 text-sm">
                       <span className="capitalize px-3 py-1 rounded-full text-xs font-medium bg-primary-100 text-primary-700">
                         {book.status.replace('-', ' ')}
                       </span>
@@ -278,7 +258,7 @@ export default function BooksPage() {
                   <div className="w-full bg-gray-200 rounded-full h-3">
                     <div
                       className="bg-primary-600 h-3 rounded-full transition-all duration-300"
-                      style={{ width: `${progress}%` }}
+                      style={{ width: `${Math.min(progress, 100)}%` }}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Changes Made

This PR fixes the books page to improve the progress tracking functionality:

### 1. ✅ Removed "Total Pages" and "Current Page" displays
- Removed the `{book.current_page} / {book.total_pages} pages` display from the book card
- Cleaned up the UI to only show the status badge

### 2. ✅ Use progress percentage field directly from database
- Changed from storing `total_pages` and `current_page` to storing `progress` (0-100%)
- Updated form to accept progress as a percentage input (0-100)
- Removed the `calculateProgress()` function as it's no longer needed

### 3. ✅ Fixed NaN% progress calculation
- Now using `book.progress || 0` directly from the database with fallback to 0
- Added `Math.min(progress, 100)` to ensure the progress bar never exceeds 100%
- This eliminates the NaN% issue that occurred when dividing by zero or undefined values

### 4. ✅ Examined and updated the code
- Simplified the form data structure
- Updated all CRUD operations to work with the new `progress` field
- Maintained all existing functionality (add, edit, delete, status tracking)

## Technical Details

**Before:**
- Used `total_pages` and `current_page` fields
- Calculated progress: `(current_page / total_pages) * 100`
- Could result in NaN% when total_pages was 0 or undefined

**After:**
- Uses single `progress` field (0-100)
- Direct percentage value from database
- Guaranteed valid percentage with fallback to 0

## Testing Recommendations

Please ensure your Supabase `books` table has a `progress` column:
```sql
ALTER TABLE books ADD COLUMN progress INTEGER DEFAULT 0;
```

Or if migrating from the old schema:
```sql
-- If you want to preserve existing data
UPDATE books SET progress = ROUND((current_page::FLOAT / NULLIF(total_pages, 0)) * 100);
-- Then optionally remove old columns
ALTER TABLE books DROP COLUMN current_page, DROP COLUMN total_pages;
```